### PR TITLE
Small fix for type in module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Run `go get github.com/michaelbironneau/garbler`. If you want to use it as a com
 The API is simple, clean, and comes with presets and sensible defaults:
 ```go
 import (
-	garbler "github/michaelbironneau/garbler/lib"
+	garbler "github.com/michaelbironneau/garbler/lib"
 	"fmt"
 )
 


### PR DESCRIPTION
Hello!

Please check it. You have broken path to module and I could not compile example code:

``` bash
go build selfbuild.go 
selfbuild.go:30:2: cannot find package "github/michaelbironneau/garbler/lib" in any of:
    /usr/local/go/src/github/michaelbironneau/garbler/lib (from $GOROOT)
    /root/gofolder/src/github/michaelbironneau/garbler/lib (from $GOPATH)
```

So after this fix everything going OK.

Thanks!
